### PR TITLE
fix: docs about default ldflag template (#1265)

### DIFF
--- a/www/content/build.md
+++ b/www/content/build.md
@@ -49,7 +49,7 @@ builds:
       - ./dontoptimizeme=-N
 
     # Custom ldflags templates.
-    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
+    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
     ldflags:
      - -s -w -X main.build={{.Version}}
      - ./usemsan=-msan


### PR DESCRIPTION
The docs state that the default ldflags includes the ShortCommit but in
reality the code uses the longer Commit value instead. This behavior has
existed since the defaults were introduced ~3 years ago in commit
4af2cb0.

Fixes #1264

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
