### PR TITLE
fix: use long git arg for quiet (#1325)

### DIFF
--- a/internal/pipe/git/git.go
+++ b/internal/pipe/git/git.go
@@ -114,11 +114,11 @@ func validate(ctx *context.Context) error {
 }
 
 func getShortCommit() (string, error) {
-	return git.Clean(git.Run("show", "--format='%h'", "HEAD", "-q"))
+	return git.Clean(git.Run("show", "--format='%h'", "HEAD", "--quiet"))
 }
 
 func getFullCommit() (string, error) {
-	return git.Clean(git.Run("show", "--format='%H'", "HEAD", "-q"))
+	return git.Clean(git.Run("show", "--format='%H'", "HEAD", "--quiet"))
 }
 
 func getTag() (string, error) {


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
