### PR TITLE
chore(deps): bump github.com/kamilsk/retry/v4 from 4.5.0 to 4.7.1 (#1…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/goreleaser/nfpm v1.1.10
 	github.com/imdario/mergo v0.3.8
 	github.com/jarcoal/httpmock v1.0.4
-	github.com/kamilsk/retry/v4 v4.5.0
+	github.com/kamilsk/retry/v4 v4.7.1
 	github.com/mattn/go-zglob v0.0.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgb
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kamilsk/retry/v4 v4.5.0 h1:TcfpmIdzFEfSWLwHJhA+WPAmo5qT2pl/HqqzFat2M+I=
 github.com/kamilsk/retry/v4 v4.5.0/go.mod h1:pIQtBtycHTXScrJmpu3N2SSBT07s07Uruq2Au1aRLks=
+github.com/kamilsk/retry/v4 v4.7.1 h1:mNg/RQ1X9QlInxBqz63ubBXgh/7D63aePBWZbQQr7pE=
+github.com/kamilsk/retry/v4 v4.7.1/go.mod h1:pIQtBtycHTXScrJmpu3N2SSBT07s07Uruq2Au1aRLks=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
…358)

Bumps [github.com/kamilsk/retry/v4](https://github.com/kamilsk/retry) from 4.5.0 to 4.7.1.
- [Release notes](https://github.com/kamilsk/retry/releases)
- [Commits](https://github.com/kamilsk/retry/compare/v4.5.0...v4.7.1)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

<!-- Why is this change being made? -->

<!-- # Provide links to any relevant tickets, URLs or other resources -->
